### PR TITLE
chore: drop support for Node.js 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "greenkeeper-postpublish": "^1.0.0"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": ">= 4"
   },
   "main": "./bin/hubot",
   "private": true,


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 0.10